### PR TITLE
Split correct numtimes

### DIFF
--- a/.github/workflows/CI_python.yaml
+++ b/.github/workflows/CI_python.yaml
@@ -20,7 +20,8 @@ jobs:
 
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip setuptools wheel
+        python -m pip install --upgrade pip  wheel
+        python -m pip install setuptools==69.5.1
         pip install -r ./bin/requirements.txt
 
     - name: Run unittest

--- a/bin/json_schema.py
+++ b/bin/json_schema.py
@@ -44,6 +44,11 @@ class JsonSchema(ABC):
 
         column_name_list = []
         for i, dictionary in enumerate(self.transform_arg):
+
+            # None can be inside this list of arguments if that is the case just ignore it. It will be handeled later on.
+            if dictionary is None:
+                continue
+
             column_name = dictionary["column_name"]
             
             # If already present as a name throw an error
@@ -71,6 +76,10 @@ class JsonSchema(ABC):
         # Iterate through the given dictionary becuse more than one column_name values could be specified for ex.
         for i, col_name_dictionary in enumerate(self.transform_arg):
             
+            # None can be inside this list of arguments if that is the case just ignore it. It will be handeled later on.
+            if col_name_dictionary is None:
+                continue
+
             # take into account that there could be the keyword default
             if col_name_dictionary["params"] == "default":
                 continue
@@ -182,6 +191,22 @@ class JsonSchema(ABC):
                     tmp_param_dict[param_name] = param_value[param_index]
                 return {"name": key, "params": tmp_param_dict}  
                 
+    
+    def unique_dicts_in_list(self, dict_list: list) -> list:
+        """
+        function is pretty straight forwrd: it checks if all elements in a list are unique and returns only unique once.
+        This is not a private function because is called from outside this file as well.
+        """
+        unique_list = []
+        for d in dict_list:
+            is_unique = True
+            for unique in unique_list:
+                if d == unique:
+                    is_unique = False
+                    break
+            if is_unique:
+                unique_list.append(d)
+        return unique_list
 
 
     def transform_column_wise_combination(self) -> list:
@@ -214,6 +239,22 @@ class JsonSchema(ABC):
             transformed2 (p1 = 3.5) - othertransformed (p1 = 6, p2 = 9)
         """
 
+        # check if there is None  among trasform arguments. if there is return the keyword referring to no transformation.
+        all_transform_combination = []
+        buffer_list = []
+        for transform_argument in self.transform_arg:
+            if transform_argument is None:
+                # add keyword for no transformation
+                all_transform_combination.append(None)
+            else:
+                buffer_list.append(transform_argument)
+
+        # update the trasform arguments, basically removing None values that would throw errors later on in the code
+        self.transform_arg = buffer_list
+
+        # check that no more than one None was added to the all_transform_combination
+        all_transform_combination = self.unique_dicts_in_list(all_transform_combination)
+
         # reshape transform entry in a nested dictionary, with structure {col_name: { transformed_name : {p1 : [1]} }} 
         transform_as_dict = self._reshape_transform_dict()
             
@@ -221,7 +262,6 @@ class JsonSchema(ABC):
         transformed_combination_list = self._generate_cartesian_product_combinations(transform_as_dict)
 
         # for each transformed combination create the column wise selection of parameters associated
-        all_transform_combination = []
         for transform_combo_tuple in transformed_combination_list:
             # select the parameter iterating through the total number of parameters associated to the specific transformed combination under selection. This value is the second value of the tuple in which the actual dictionary of transformed combination is.
             for params_index in range(transform_combo_tuple[1]):
@@ -258,7 +298,22 @@ class JsonSchema(ABC):
         It returns a list of dictionaries, where each dictionary represents a combination of parameters for a split.
         """
 
+        # check if there is None  among trasform arguments. if there is return the keyword referring to no transformation.
         list_split_comibinations = []
+        buffer_list = []
+        for split_argument in self.split_arg:
+            if split_argument is None:
+                # add keyword  for no split
+                list_split_comibinations.append(None)
+            else:
+                buffer_list.append(split_argument)
+
+        # update the split arguments, basically removing None values that would throw errors later on in the code
+        self.split_arg = buffer_list  
+        
+        # check that no more than one None was added to the all_transform_combination
+        list_split_comibinations = self.unique_dicts_in_list(list_split_comibinations)
+
         # iterate through the split entry and return a list of split possibilities, where each splitter_name has one/set of one parametyers
         for i, split_dict in enumerate(self.split_arg):
             # jsut create a new dictionary for each set of params associated to each split_name, basically if a splitter has more than one element in his params: then they should be decoupled so to have each splitter with only one value for params:

--- a/bin/launch_check_model.py
+++ b/bin/launch_check_model.py
@@ -25,43 +25,7 @@ def get_args():
     args = parser.parse_args()
     return args
 
-"""
-class CheckModelWrapper():
 
-    def __init__(self, model: nn.Module, config_file: str, data_path: str, experiment: object):
-        # open the yaml tune config file and get an instance of it . aka choose values when needed.
-        yaml_config = YamlRayConfigLoader(config_file)
-        config_instance = yaml_config.get_config_instance()
-        print("tested config: ", config_instance)
-        self.model = model(**config_instance["model_params"])
-        # get the optimizer from pytorch
-        optimizer = getattr(torch.optim, config_instance["optimizer_params"]["method"])
-        # get the loss dict from the config and replace the each value with the actual imported/initialized loss dfunction 
-        self.loss_dict = yaml_config.initialize_loss_functions(config_instance["loss_params"])
-        # instantiate the optimizer, get all optimizer parameters except the names of the optimizers themselves
-        optimizer_params_values = {key: value for key, value in config_instance["optimizer_params"].items() if key != "method"}
-        self.optimizer = optimizer(self.model.parameters(), **optimizer_params_values)
-        # train_data is a TorchDataset object
-        self.train_data = torch.utils.data.DataLoader(handlertorch.TorchDataset(os.path.abspath(data_path), experiment, split=None), batch_size=config_instance["data_params"]["batch_size"], shuffle=True)
-
-    def check_model(self):
-        # get the initial model weights into a variable 
-        initial_model_weights = deepcopy(self.model.state_dict())
-        # load one sample of the data
-
-        x, y, meta = next(iter(self.train_data))
-        # train the model for one epoch
-        loss, output = self.model.batch(x, y, self.loss_dict, self.optimizer)
-        # check the model weights have changed, and print if it has
-        for key in initial_model_weights:
-            if torch.equal(initial_model_weights[key], self.model.state_dict()[key]):
-                print(f"Model weights have not changed for key {key}")
-            else:
-                print(f"Model weights have changed for key {key}")
-
-        # print the computed loss, displaying loss_dict as well
-        print(f"Loss computed with {self.loss_dict} is {loss.item()}")
-"""
 
 def main(data_path: str, model_path: str, experiment_config: str, config_path: str, num_samples: int):
 

--- a/bin/launch_interpret_json.py
+++ b/bin/launch_interpret_json.py
@@ -3,7 +3,7 @@
 import argparse
 import json
 import os
-import urllib.parse
+import re
 
 from json_schema import JsonSchema
 from typing import Union
@@ -34,6 +34,7 @@ def get_args():
 
 
 def unique_dicts_in_list(dict_list: list) -> list:
+
     unique_list = []
     for d in dict_list:
         is_unique = True
@@ -47,9 +48,20 @@ def unique_dicts_in_list(dict_list: list) -> list:
 
 
 def dict_to_filename_safe_string(d: Union[dict, None]) -> str:
+
     # making the dictionary into some sort of hash key avoiding problematic digits for filename and nextflow use.
-    json_str = json.dumps(d, separators=('_', '_')).replace("-", "_")
-    return urllib.parse.quote(json_str)
+    pattern = r"[^\d\w\.]"   # this preserves numbers 0-9 letters a-z and dots
+    if d is None:
+        return "no_split"
+    else:
+        map_key = ""
+        for first_level_val in d.values():
+            if isinstance(first_level_val, dict):
+                for second_level_val in first_level_val.values():
+                    map_key += re.sub(pattern, "_", f"{second_level_val}")
+            else:
+                map_key += re.sub(pattern, "_", f"{first_level_val}")
+        return map_key.replace("__", "_")[:-1]
 
 
 

--- a/bin/launch_interpret_json.py
+++ b/bin/launch_interpret_json.py
@@ -99,7 +99,6 @@ def interpret_json(input_json: dict) -> list:
 
     # check that also list_of_json_to_write has only unique combinations
     unique_list_of_json_to_write = schema.unique_dicts_in_list(list_of_json_to_write)
-    print(unique_list_of_json_to_write)
 
     return unique_list_of_json_to_write, unique_split_combinations
 

--- a/bin/launch_interpret_json.py
+++ b/bin/launch_interpret_json.py
@@ -142,10 +142,10 @@ def main(config_json: str, out_dir_path: str) -> str:
     for i, interpreted_json in enumerate(list_json):
 
         # create the file names: one for the specifc experiment info (all info), and one with exp_name and transform info
-        allinfo_file_path = os.path.join(out_dir_path, f"{suffix}-#{i+1}-allinfo.json")
+        allinfo_file_path = os.path.join(out_dir_path, f"{suffix}-{i+1}-allinfo.json")
         # make also the transform unique json have the split argument content as filename keyward. needed by nextflow to match the 2 later on.
         hash_key = dict_to_filename_safe_string(interpreted_json["split"])
-        transform_file_path = os.path.join(out_dir_path, f"{suffix}-#{i+1}-transform-{hash_key}.json")
+        transform_file_path = os.path.join(out_dir_path, f"{suffix}-{i+1}-transform-{hash_key}.json")
 
         with open(allinfo_file_path, 'w') as allinfo_file, open(transform_file_path, 'w') as transform_file :
             # TODO make all info file into a yaml reusable by the piepline but with only one combination

--- a/bin/launch_shuffle_csv.py
+++ b/bin/launch_shuffle_csv.py
@@ -31,7 +31,7 @@ def main(data_csv, config_json, out_path):
     TODO major changes when this is going to select a given shuffle method and integration with split.
     """
     
-    # open and read Json, jsut to extract the experiment name, so all other fields are scratched
+    # open and read Json, just to extract the experiment name, so all other fields are scratched
     config = {}
     with open(config_json, 'r') as in_json:
         tmp = json.load(in_json)
@@ -39,7 +39,7 @@ def main(data_csv, config_json, out_path):
         config["split"] = {"name": "RandomSplitter", "params": {}}
 
     # write the config modified, this will be associated to the shuffled data. TODO better solution to renaming like this
-    modified_json = os.path.splitext(os.path.basename(data_csv))[0] + '-shuffled.json'
+    modified_json = os.path.splitext(os.path.basename(data_csv))[0] + '-shuffled-allinfo.json'
     with open(modified_json, 'w') as out_json:
         json.dump(config, out_json)
 

--- a/bin/launch_shuffle_csv.py
+++ b/bin/launch_shuffle_csv.py
@@ -39,7 +39,7 @@ def main(data_csv, config_json, out_path):
         config["split"] = {"name": "RandomSplitter", "params": {}}
 
     # write the config modified, this will be associated to the shuffled data. TODO better solution to renaming like this
-    modified_json = os.path.splitext(os.path.basename(data_csv))[0] + '-shuffled-allinfo.json'
+    modified_json = os.path.splitext(os.path.basename(data_csv))[0] + '-shuffled-experiment.json'
     with open(modified_json, 'w') as out_json:
         json.dump(config, out_json)
 

--- a/bin/launch_shuffle_csv.py
+++ b/bin/launch_shuffle_csv.py
@@ -32,14 +32,15 @@ def main(data_csv, config_json, out_path):
     """
     
     # open and read Json, just to extract the experiment name, so all other fields are scratched
-    config = {}
+    config = None
     with open(config_json, 'r') as in_json:
         tmp = json.load(in_json)
-        config["experiment"] = tmp["experiment"]
-        config["split"] = {"name": "RandomSplitter", "params": {}}
+        config = tmp
+        # add fake transform informations
+        config["transform"] = "shuffle (special case)"
 
     # write the config modified, this will be associated to the shuffled data. TODO better solution to renaming like this
-    modified_json = os.path.splitext(os.path.basename(data_csv))[0] + '-shuffled-experiment.json'
+    modified_json = os.path.splitext(os.path.basename(data_csv))[0].split('-split')[0] + '-shuffled-experiment.json'
     with open(modified_json, 'w') as out_json:
         json.dump(config, out_json)
 
@@ -52,15 +53,8 @@ def main(data_csv, config_json, out_path):
     # shuffle the data
     csv_obj.shuffle_labels()
 
-    # split the data
-    # split column already present in csv , override it with random split (default splitter)
-    # TODO change this behaviour to do both, maybe
-    csv_obj.add_split(config["split"], force = True)
-
     # save the modified csv
     csv_obj.save(out_path)
-
-
 
 
 

--- a/bin/src/analysis/analysis_default.py
+++ b/bin/src/analysis/analysis_default.py
@@ -273,6 +273,10 @@ class AnalysisRobustness(Analysis):
         rows, cols = self.get_grid_shape(len(self.metrics))
         fig, axs = plt.subplots(rows, cols, figsize=figsize)
 
+        # if there is only one plot plot.sublots will output a simple list, while if there are more than one it will return a list of lists. there is the need to unify the two cases. following line does this
+        if not isinstance(axs, np.ndarray):
+            axs = np.array([axs])
+
         for i,ax in enumerate(axs.flat):
             if i >= len(self.metrics):
                 ax.axis('off')
@@ -302,6 +306,10 @@ class AnalysisRobustness(Analysis):
         # create figure
         rows, cols = self.get_grid_shape(len(df['model'].unique()))
         fig, axs = plt.subplots(rows, cols, figsize=figsize)
+
+        # if there is only one plot plot.sublots will output <class 'matplotlib.axes._axes.Axes'>, while if there are more than one it will return a np.ndarray. there is the need to unify the two cases. following line does this
+        if not isinstance(axs, np.ndarray):
+            axs = np.array([axs])
 
         # plot each model
         for i,ax in enumerate(axs.flat):

--- a/configs/modules.config
+++ b/configs/modules.config
@@ -35,7 +35,7 @@ process {
 
     withName: "STIMULUS_ANALYSIS_DEFAULT" {
         publishDir = [
-            path: { "${params.outdir}/${workflow.runName}_" + "${workflow.start}/".replaceAll('[-:]', '_').split('\\.')[0] + "/analysis_default" },
+            path: { "${params.outdir}/${workflow.runName}_" + "${workflow.start}/".replaceAll('[-:]', '_').split('\\.')[0] + "/analysis_default/" + "${split_transform_key}" },
             mode: params.publish_dir_mode,
             overwrite: true
         ]

--- a/configs/modules.config
+++ b/configs/modules.config
@@ -17,9 +17,9 @@ process {
     }
 
     withName: "TORCH_TUNE" {
-        ext.prefix = { "${combination_key}" }
+        ext.prefix = { "${combination_key}".split(' ')[0].split('\\.')[0..-2].join("_") + "-" + "${combination_key}".split(' ')[2] }
         publishDir = [
-            path: { "${params.outdir}/${workflow.runName}_" + "${workflow.start}/".replaceAll('[-:]', '_').split('\\.')[0] + "/" + "${combination_key}" },
+            path: { "${params.outdir}/${workflow.runName}_" + "${workflow.start}/".replaceAll('[-:]', '_').split('\\.')[0] + "/" + "${combination_key}".split(' ')[0].split('\\.')[0..-2].join("_") + "-" + "${combination_key}".split(' ')[2] },
             mode: "copy",
             overwrite: true,
             saveAs: { filename -> if (filename.endsWith("-metrics.csv")) "best_model-metrics.csv"

--- a/configs/modules.config
+++ b/configs/modules.config
@@ -17,11 +17,19 @@ process {
     }
 
     withName: "TORCH_TUNE" {
-        ext.prefix = { "${parsed_json}".tokenize('/')[-1].tokenize('.')[0] }
+        ext.prefix = { "${combination_key}" }
         publishDir = [
-            path: { "${params.outdir}/${workflow.runName}_" + "${workflow.start}/".replaceAll('[-:]', '_').split('\\.')[0] + "/" + "${parsed_json}".tokenize('/')[-1].tokenize('.')[0] },
-            mode: params.publish_dir_mode,
-            overwrite: true
+            path: { "${params.outdir}/${workflow.runName}_" + "${workflow.start}/".replaceAll('[-:]', '_').split('\\.')[0] + "/" + "${combination_key}" },
+            mode: "copy",
+            overwrite: true,
+            saveAs: { filename -> if (filename.endsWith("-metrics.csv")) "best_model-metrics.csv"
+                else if (filename.endsWith("-config.json")) "best_model-tuneconfig.json"
+                else if (filename.endsWith("-model.pt")) "best_model.pt"
+                else if (filename.endsWith("-optimizer.pt")) "best_model-optimizer.pt"
+                else if (filename.endsWith(".csv")) "training_data.csv"
+                else if (filename.endsWith(".json")) "experiment_config.json"
+                else filename
+             }
         ]
     }
 

--- a/examples/test.json
+++ b/examples/test.json
@@ -6,12 +6,14 @@
             "column_name": "hello:input:dna",
             "name": ["UniformTextMasker"],
             "params": [{"probability": [0.1, 0.2]}]
-        }
+        },
+        null
     ],
     "split": [
         {
             "name": "RandomSplitter",
             "params": [{"split": [[0.5, 0.5, 0.0], [0.34, 0.33, 0.33]]}]
-        }
+        },
+        null
     ]
 }

--- a/examples/test.json
+++ b/examples/test.json
@@ -12,7 +12,7 @@
     "split": [
         {
             "name": "RandomSplitter",
-            "params": [{"split": [[0.5, 0.5, 0.0], [0.34, 0.33, 0.33]]}]
+            "params": [{"split": [[0.34, 0.33, 0.33]]}]
         },
         null
     ]

--- a/main.nf
+++ b/main.nf
@@ -50,15 +50,15 @@ workflow {
         completion_message
     )
     prepared_data = HANDLE_DATA.out.data
-    HANDLE_DATA.out.data.view()
-    /*
+    //HANDLE_DATA.out.data.view()
+    
     HANDLE_TUNE(
         params.model,
         params.train_conf,
         prepared_data
     )
     // HANDLE_TUNE.out.model.view()
-
+    /*
     // this part works, but the docker container is not updated with matplotlib yet
     HANDLE_ANALYSIS(
         HANDLE_TUNE.out.tune_out,

--- a/main.nf
+++ b/main.nf
@@ -51,7 +51,7 @@ workflow {
     )
     prepared_data = HANDLE_DATA.out.data
     //HANDLE_DATA.out.data.view()
-
+    /*
     HANDLE_TUNE(
         params.model,
         params.train_conf,
@@ -64,7 +64,7 @@ workflow {
         HANDLE_TUNE.out.tune_out,
         HANDLE_TUNE.out.model
     ) 
-
+    */
 }
 
 

--- a/main.nf
+++ b/main.nf
@@ -49,8 +49,8 @@ workflow {
         params.exp_conf,
         completion_message
     )
-    prepared_data = HANDLE_DATA.out.data
-    //HANDLE_DATA.out.data.view()
+    /* prepared_data = HANDLE_DATA.out.data
+    HANDLE_DATA.out.data.view()
     
     HANDLE_TUNE(
         params.model,
@@ -58,7 +58,7 @@ workflow {
         prepared_data
     )
     // HANDLE_TUNE.out.model.view()
-    /*
+    
     // this part works, but the docker container is not updated with matplotlib yet
     HANDLE_ANALYSIS(
         HANDLE_TUNE.out.tune_out,

--- a/main.nf
+++ b/main.nf
@@ -50,7 +50,7 @@ workflow {
         completion_message
     )
     prepared_data = HANDLE_DATA.out.data
-    //HANDLE_DATA.out.data.view()
+    HANDLE_DATA.out.data.view()
     /*
     HANDLE_TUNE(
         params.model,

--- a/main.nf
+++ b/main.nf
@@ -49,22 +49,23 @@ workflow {
         params.exp_conf,
         completion_message
     )
-    /* prepared_data = HANDLE_DATA.out.data
-    HANDLE_DATA.out.data.view()
+    prepared_data = HANDLE_DATA.out.data
+    //HANDLE_DATA.out.data.view()
     
     HANDLE_TUNE(
         params.model,
         params.train_conf,
         prepared_data
     )
-    // HANDLE_TUNE.out.model.view()
+    //HANDLE_TUNE.out.model.view()
+    //HANDLE_TUNE.out.tune_out.view()
     
     // this part works, but the docker container is not updated with matplotlib yet
     HANDLE_ANALYSIS(
         HANDLE_TUNE.out.tune_out,
         HANDLE_TUNE.out.model
     ) 
-    */
+    
 }
 
 

--- a/modules/local/interpret_json.nf
+++ b/modules/local/interpret_json.nf
@@ -10,7 +10,7 @@ process INTERPRET_JSON {
     val message_from_check_model // only here to ensure that this module waits for check_model module to actually run
 
     output:
-    path ("*-allinfo.json"), emit: allinfo_json
+    path ("*-experiment.json"), emit: experiment_json
     path ("*-split-*.json"), emit: split_json
     path ("*-transform-*.json"), emit: transform_json
 
@@ -21,10 +21,10 @@ process INTERPRET_JSON {
 
     stub:
     """
-    touch test-#1-allinfo.json
+    touch test-#1-experiment.json
     touch test-split-null.json
     touch test-#1-transform-null.json
-    touch test-#2-allinfo.json
+    touch test-#2-experiment.json
     touch test-split-null.json
     touch test-#2-transform-null.json
     """

--- a/modules/local/interpret_json.nf
+++ b/modules/local/interpret_json.nf
@@ -22,10 +22,10 @@ process INTERPRET_JSON {
     stub:
     """
     touch test-#1-allinfo.json
-    touch test-#1-split.json
-    touch test-#1-transform.json
+    touch test-split-null.json
+    touch test-#1-transform-null.json
     touch test-#2-allinfo.json
-    touch test-#2-split.json
-    touch test-#2-transform.json
+    touch test-split-null.json
+    touch test-#2-transform-null.json
     """
 }

--- a/modules/local/interpret_json.nf
+++ b/modules/local/interpret_json.nf
@@ -10,17 +10,22 @@ process INTERPRET_JSON {
     val message_from_check_model // only here to ensure that this module waits for check_model module to actually run
 
     output:
-    path("json_dir/*.json"), emit: interpreted_json
+    path ("*-allinfo.json"), emit: allinfo_json
+    path ("*-split-*.json"), emit: split_json
+    path ("*-transform-*.json"), emit: transform_json
 
     script:
     """
-    launch_interpret_json.py -j ${user_json} -d json_dir 
+    launch_interpret_json.py -j ${user_json} 
     """
 
     stub:
     """
-    mkdir json_dir
-    touch json_dir/test-#1.json
-    touch json_dir/test-#2.json
+    touch test-#1-allinfo.json
+    touch test-#1-split.json
+    touch test-#1-transform.json
+    touch test-#2-allinfo.json
+    touch test-#2-split.json
+    touch test-#2-transform.json
     """
 }

--- a/modules/local/stimulus_analysis_default.nf
+++ b/modules/local/stimulus_analysis_default.nf
@@ -6,7 +6,7 @@ process STIMULUS_ANALYSIS_DEFAULT {
     container "alessiovignoli3/stimulus:stimulus_v0.2"
 
     input:
-    tuple val(original_csv), \
+    tuple val(combination_key), \
           path(data), \
           path(experiment_config), \
           path(model_config), \

--- a/modules/local/stimulus_analysis_default.nf
+++ b/modules/local/stimulus_analysis_default.nf
@@ -1,12 +1,13 @@
 
 process STIMULUS_ANALYSIS_DEFAULT {
 
-    tag "$model-$data"
+    tag "${model} - ${split_transform_key}"
     label 'process_medium'
     container "alessiovignoli3/stimulus:stimulus_v0.2"
 
     input:
-    tuple val(combination_key), \
+    tuple val(split_transform_key), \
+          val(combination_key), \
           path(data), \
           path(experiment_config), \
           path(model_config), \
@@ -21,12 +22,12 @@ process STIMULUS_ANALYSIS_DEFAULT {
     script:
     """
     launch_analysis_default.py \
-        -m $model \
-        -w $weights \
-        -me $metrics \
-        -ec $experiment_config \
-        -mc $model_config \
-        -d $data \
+        -m ${model} \
+        -w ${weights} \
+        -me ${metrics} \
+        -ec ${experiment_config} \
+        -mc ${model_config} \
+        -d ${data} \
         -o .
     """
 

--- a/modules/local/stimulus_shuffle_csv.nf
+++ b/modules/local/stimulus_shuffle_csv.nf
@@ -1,27 +1,27 @@
 
 process STIMULUS_SHUFFLE_CSV {
 
-    tag "$random_parsed_json"
+    tag "${original_csv}"
     label 'process_medium'
     container 'alessiovignoli3/stimulus:stimulus_v0.2'
 
     input:
-    tuple path(original_csv), path(random_parsed_json)
+    tuple val(random_combination_key), path(random_parsed_json), path(original_csv)
 
     output:
     // this type of output is so it is more easily unifiable with the output of the noise module.
-    tuple val("${original_csv}"), path("*.json"), path(output), emit: csv_shuffled
+    tuple val("${original_csv.simpleName}-shuffle"), path("*.json"), path(output), emit: csv_shuffled
 
     script:
-    output = "${original_csv.baseName}-shuffled.csv"
+    output = "${original_csv.simpleName}-shuffle.csv"
     """
     launch_shuffle_csv.py -c ${original_csv} -j ${random_parsed_json} -o ${output}
     """
 
     stub:
-    output = "${original_csv.baseName}-shuffled.csv"
+    output = "${original_csv.simpleName}-shuffled.csv"
     """
     touch ${output}
-    touch "${original_csv.baseName}-shuffled.json"
+    touch "${original_csv.simpleName}-shuffled-allinfo.json"
     """
 }

--- a/modules/local/stimulus_shuffle_csv.nf
+++ b/modules/local/stimulus_shuffle_csv.nf
@@ -10,7 +10,7 @@ process STIMULUS_SHUFFLE_CSV {
 
     output:
     // this type of output is so it is more easily unifiable with the output of the noise module.
-    tuple val("${original_csv.simpleName}-shuffle"), path("*.json"), path(output), emit: csv_shuffled
+    tuple val("${original_csv} - shuffle"), path("*.json"), path(output), emit: csv_shuffled
 
     script:
     output = "${original_csv.simpleName}-shuffle.csv"

--- a/modules/local/stimulus_shuffle_csv.nf
+++ b/modules/local/stimulus_shuffle_csv.nf
@@ -22,6 +22,6 @@ process STIMULUS_SHUFFLE_CSV {
     output = "${original_csv.simpleName}-shuffled.csv"
     """
     touch ${output}
-    touch "${original_csv.simpleName}-shuffled-allinfo.json"
+    touch "${original_csv.simpleName}-shuffled-experiment.json"
     """
 }

--- a/modules/local/stimulus_shuffle_csv.nf
+++ b/modules/local/stimulus_shuffle_csv.nf
@@ -1,21 +1,21 @@
 
 process STIMULUS_SHUFFLE_CSV {
 
-    tag "${original_csv}"
+    tag "${original_csv} - shuffles"
     label 'process_medium'
     container 'alessiovignoli3/stimulus:stimulus_v0.2'
 
     input:
-    tuple val(random_combination_key), path(random_parsed_json), path(original_csv)
+    tuple val(split_transform_key), path(splitted_csv), path(split_json), path(original_csv)
 
     output:
     // this type of output is so it is more easily unifiable with the output of the noise module.
-    tuple val("${original_csv} - shuffle"), path("*.json"), path(output), emit: csv_shuffled
+    tuple val("${original_csv} - shuffle"), val(split_transform_key), path("*.json"), path(output), emit: csv_shuffled
 
     script:
     output = "${original_csv.simpleName}-shuffle.csv"
     """
-    launch_shuffle_csv.py -c ${original_csv} -j ${random_parsed_json} -o ${output}
+    launch_shuffle_csv.py -c ${splitted_csv} -j ${split_json} -o ${output}
     """
 
     stub:

--- a/modules/local/stimulus_split_csv.nf
+++ b/modules/local/stimulus_split_csv.nf
@@ -1,7 +1,7 @@
 
 process STIMULUS_SPLIT_CSV {
     
-    tag "${original_csv}-${split_transform_key}"
+    tag "${original_csv} - ${split_transform_key}"
     label 'process_low'
     container 'alessiovignoli3/stimulus:stimulus_v0.2'
 

--- a/modules/local/stimulus_split_csv.nf
+++ b/modules/local/stimulus_split_csv.nf
@@ -6,10 +6,10 @@ process STIMULUS_SPLIT_CSV {
     container 'alessiovignoli3/stimulus:stimulus_v0.2'
 
     input:
-    tuple path(csv), path(parsed_json)
+    tuple val(map_key), path(parsed_json), path(csv)
 
     output:
-    tuple val("${csv}"), path(parsed_json), path(output), emit: csv_with_split
+    tuple val(map_key), val("${csv}"), path(parsed_json), path(output), emit: csv_with_split
 
     script:
     output = "${csv.baseName}-${parsed_json.baseName}.csv"

--- a/modules/local/stimulus_split_csv.nf
+++ b/modules/local/stimulus_split_csv.nf
@@ -1,24 +1,24 @@
 
 process STIMULUS_SPLIT_CSV {
     
-    tag "$parsed_json"
+    tag "$split_transform_key"
     label 'process_low'
     container 'alessiovignoli3/stimulus:stimulus_v0.2'
 
     input:
-    tuple val(map_key), path(parsed_json), path(csv)
+    tuple val(split_transform_key), path(split_json), path(original_csv)
 
     output:
-    tuple val(map_key), val("${csv}"), path(parsed_json), path(output), emit: csv_with_split
+    tuple val(split_transform_key), path(output), path(split_json), path(original_csv), emit: csv_with_split
 
     script:
-    output = "${csv.baseName}-${parsed_json.baseName}.csv"
+    output = "${original_csv.simpleName}-split.csv"
     """
-    launch_split_csv.py -c ${csv} -j ${parsed_json} -o ${output}
+    launch_split_csv.py -c ${original_csv} -j ${split_json} -o ${output}
     """
 
     stub:
-    output = "${csv.baseName}-${parsed_json.baseName}.csv"
+    output = "${original_csv.simpleName}-split.csv"
     """
     touch ${output}
     """

--- a/modules/local/stimulus_split_csv.nf
+++ b/modules/local/stimulus_split_csv.nf
@@ -1,7 +1,7 @@
 
 process STIMULUS_SPLIT_CSV {
     
-    tag "$split_transform_key"
+    tag "${original_csv}-${split_transform_key}"
     label 'process_low'
     container 'alessiovignoli3/stimulus:stimulus_v0.2'
 

--- a/modules/local/stimulus_transform_csv.nf
+++ b/modules/local/stimulus_transform_csv.nf
@@ -1,7 +1,7 @@
 
 process STIMULUS_TRANSFORM_CSV {
 
-    tag "${combination_key}-${original_csv}"
+    tag "${original_csv} - ${combination_key}"
     label 'process_medium'
     container 'alessiovignoli3/stimulus:stimulus_v0.2'
 

--- a/modules/local/stimulus_transform_csv.nf
+++ b/modules/local/stimulus_transform_csv.nf
@@ -19,7 +19,7 @@ process STIMULUS_TRANSFORM_CSV {
     """
 
     stub:
-    output = "${original_csv.simpleName}-trans.csv"
+    output = "${original_csv.simpleName}-${combination_key}-trans.csv"
     """
     touch ${output}
     """

--- a/modules/local/stimulus_transform_csv.nf
+++ b/modules/local/stimulus_transform_csv.nf
@@ -13,7 +13,7 @@ process STIMULUS_TRANSFORM_CSV {
     tuple  val(combination_key), val(split_transform_key), path(transform_json), path(output), path(split_json), path(original_csv), emit: transformed_data
 
     script:
-    output = "${original_csv.simpleName}-trans.csv"
+    output = "${original_csv.simpleName}-${combination_key}-trans.csv"
     """
     launch_transform_csv.py -c ${splitted_csv} -j ${transform_json} -o ${output}
     """

--- a/modules/local/stimulus_transform_csv.nf
+++ b/modules/local/stimulus_transform_csv.nf
@@ -9,7 +9,8 @@ process STIMULUS_TRANSFORM_CSV {
     tuple val(split_transform_key), val(combination_key), path(transform_json), path(splitted_csv), path(split_json), path(original_csv)
 
     output:
-    tuple val(split_transform_key), val(combination_key), path(transform_json), path(output), path(split_json), path(original_csv), emit: transformed_data
+    // combination_key is put fist so that later a combine by:0 can be used to unify with the json that has allinformation (split + transform) associated with this data
+    tuple  val(combination_key), val(split_transform_key), path(transform_json), path(output), path(split_json), path(original_csv), emit: transformed_data
 
     script:
     output = "${original_csv.simpleName}-trans.csv"

--- a/modules/local/stimulus_transform_csv.nf
+++ b/modules/local/stimulus_transform_csv.nf
@@ -9,7 +9,7 @@ process STIMULUS_TRANSFORM_CSV {
     tuple val(split_transform_key), val(combination_key), path(transform_json), path(splitted_csv), path(split_json), path(original_csv)
 
     output:
-    // combination_key is put fist so that later a combine by:0 can be used to unify with the json that has allinformation (split + transform) associated with this data
+    // combination_key is put first so that later a combine by:0 can be used to unify with the json that has experiment information (split + transform) associated with this data
     tuple  val(combination_key), val(split_transform_key), path(transform_json), path(output), path(split_json), path(original_csv), emit: transformed_data
 
     script:

--- a/modules/local/stimulus_transform_csv.nf
+++ b/modules/local/stimulus_transform_csv.nf
@@ -1,24 +1,24 @@
 
 process STIMULUS_TRANSFORM_CSV {
 
-    tag "$parsed_json"
+    tag "$combination_key"
     label 'process_medium'
     container 'alessiovignoli3/stimulus:stimulus_v0.2'
 
     input:
-    tuple val(original_csv), path(parsed_json), path(splitted_csv)
+    tuple val(split_transform_key), val(combination_key), path(transform_json), path(splitted_csv), path(split_json), path(original_csv)
 
     output:
-    tuple val(original_csv), path(parsed_json), path(output), emit: transformed_data
+    tuple val(split_transform_key), val(combination_key), path(transform_json), path(output), path(split_json), path(original_csv), emit: transformed_data
 
     script:
-    output = "${splitted_csv.baseName}-trans.csv"
+    output = "${original_csv.simpleName}-trans.csv"
     """
-    launch_transform_csv.py -c ${splitted_csv} -j ${parsed_json} -o ${output}
+    launch_transform_csv.py -c ${splitted_csv} -j ${transform_json} -o ${output}
     """
 
     stub:
-    output = "${splitted_csv.baseName}-trans.csv"
+    output = "${original_csv.simpleName}-trans.csv"
     """
     touch ${output}
     """

--- a/modules/local/stimulus_transform_csv.nf
+++ b/modules/local/stimulus_transform_csv.nf
@@ -1,7 +1,7 @@
 
 process STIMULUS_TRANSFORM_CSV {
 
-    tag "$combination_key"
+    tag "${combination_key}-${original_csv}"
     label 'process_medium'
     container 'alessiovignoli3/stimulus:stimulus_v0.2'
 

--- a/modules/local/torch_tune.nf
+++ b/modules/local/torch_tune.nf
@@ -6,10 +6,11 @@ process TORCH_TUNE {
     container "alessiovignoli3/stimulus:stimulus_v0.2"
 
     input:
-    tuple val(combination_key), path(ray_tune_config), path(model), path(data_csv), path(experiment_config)
+    tuple val(combination_key), val(split_transform_key), path(ray_tune_config), path(model), path(data_csv), path(experiment_config)
 
     output:
     tuple val(combination_key),
+          val(split_transform_key),
           path(data_csv),
           path(experiment_config),
           path("*-config.json"),

--- a/modules/local/torch_tune.nf
+++ b/modules/local/torch_tune.nf
@@ -9,8 +9,8 @@ process TORCH_TUNE {
     tuple val(combination_key), val(split_transform_key), path(ray_tune_config), path(model), path(data_csv), path(experiment_config)
 
     output:
-    tuple val(combination_key),
-          val(split_transform_key),
+    tuple val(split_transform_key),
+          val(combination_key),
           path(data_csv),
           path(experiment_config),
           path("*-config.json"),

--- a/modules/local/torch_tune.nf
+++ b/modules/local/torch_tune.nf
@@ -6,12 +6,12 @@ process TORCH_TUNE {
     container "alessiovignoli3/stimulus:stimulus_v0.2"
 
     input:
-    tuple val(combination_key), path(ray_tune_config), path(model), path(data_csv), path(allinfo_json)
+    tuple val(combination_key), path(ray_tune_config), path(model), path(data_csv), path(experiment_config)
 
     output:
     tuple val(combination_key),
           path(data_csv),
-          path(allinfo_json),
+          path(experiment_config),
           path("*-config.json"),
           path("*-model.pt"),
           path("*-optimizer.pt"),
@@ -25,7 +25,7 @@ process TORCH_TUNE {
         -c ${ray_tune_config} \
         -m ${model} \
         -d ${data_csv} \
-        -e ${allinfo_json} \
+        -e ${experiment_config} \
         -o ${prefix}-model.pt \
         -bo ${prefix}-optimizer.pt \
         -bm ${prefix}-metrics.csv \

--- a/modules/local/torch_tune.nf
+++ b/modules/local/torch_tune.nf
@@ -1,7 +1,7 @@
 
 process TORCH_TUNE {
 
-    tag "${model}-${combination_key}"
+    tag "${model} - ${combination_key}"
     label 'process_high'
     container "alessiovignoli3/stimulus:stimulus_v0.2"
 

--- a/modules/local/torch_tune.nf
+++ b/modules/local/torch_tune.nf
@@ -9,7 +9,6 @@ process TORCH_TUNE {
     tuple val(original_csv), path(ray_tune_config), path(model), path(data_csv), path(parsed_json)
 
     output:
-    // TODO get the best model as well once implemented in python
     tuple val(original_csv),
           path(data_csv),
           path(parsed_json),

--- a/modules/local/torch_tune.nf
+++ b/modules/local/torch_tune.nf
@@ -1,17 +1,17 @@
 
 process TORCH_TUNE {
 
-    tag "$model-$data_csv"
+    tag "${model}-${combination_key}"
     label 'process_high'
     container "alessiovignoli3/stimulus:stimulus_v0.2"
 
     input:
-    tuple val(original_csv), path(ray_tune_config), path(model), path(data_csv), path(parsed_json)
+    tuple val(combination_key), path(ray_tune_config), path(model), path(data_csv), path(allinfo_json)
 
     output:
-    tuple val(original_csv),
+    tuple val(combination_key),
           path(data_csv),
-          path(parsed_json),
+          path(allinfo_json),
           path("*-config.json"),
           path("*-model.pt"),
           path("*-optimizer.pt"),
@@ -25,7 +25,7 @@ process TORCH_TUNE {
         -c ${ray_tune_config} \
         -m ${model} \
         -d ${data_csv} \
-        -e ${parsed_json} \
+        -e ${allinfo_json} \
         -o ${prefix}-model.pt \
         -bo ${prefix}-optimizer.pt \
         -bm ${prefix}-metrics.csv \

--- a/subworkflows/shuffle_csv.nf
+++ b/subworkflows/shuffle_csv.nf
@@ -15,13 +15,11 @@ include { STIMULUS_SHUFFLE_CSV } from '../modules/local/stimulus_shuffle_csv.nf'
 workflow SHUFFLE_CSV {
 
     take:
-    data_csv
-    json_tuple
+    csv_json_pairs
     
 
     main:
-    // if there is more than one csv then each of them will be associated to all Json. This means all the modifications will be made on all the input csv.
-    csv_json_pairs = json_tuple.combine(data_csv)
+    
     STIMULUS_SHUFFLE_CSV(csv_json_pairs)
 
 

--- a/subworkflows/shuffle_csv.nf
+++ b/subworkflows/shuffle_csv.nf
@@ -16,16 +16,14 @@ workflow SHUFFLE_CSV {
 
     take:
     data_csv
-    json
+    json_tuple
     
+
     main:
     // if there is more than one csv then each of them will be associated to all Json. This means all the modifications will be made on all the input csv.
-    csv_json_pairs = data_csv.combine(json)
-    
-    // It can be still skipped but by default is run. shuffle is set to true in nextflow.config
-    if ( params.shuffle ) {
-        STIMULUS_SHUFFLE_CSV(csv_json_pairs)
-    }
+    csv_json_pairs = json_tuple.combine(data_csv)
+    STIMULUS_SHUFFLE_CSV(csv_json_pairs)
+
 
     emit:
     shuffle_data  = STIMULUS_SHUFFLE_CSV.out.csv_shuffled

--- a/subworkflows/split_csv.nf
+++ b/subworkflows/split_csv.nf
@@ -16,13 +16,13 @@ workflow SPLIT_CSV {
 
     take:
     data_csv
-    json
+    json_tuple
 
     main:
 
     // if there is more than one csv then each of them will be associated to all Json. This means all the modifications will be made on all the input csv.
-    csv_json_pairs = data_csv.combine(json)
-    STIMULUS_SPLIT_CSV( csv_json_pairs )
+    json_csv_pairs = json_tuple.combine(data_csv)
+    STIMULUS_SPLIT_CSV( json_csv_pairs )
 
     emit:
     split_data  = STIMULUS_SPLIT_CSV.out.csv_with_split

--- a/workflows/handle_analysis.nf
+++ b/workflows/handle_analysis.nf
@@ -20,15 +20,14 @@ workflow HANDLE_ANALYSIS {
 
     main:
    
-    // 1. Run the default analysis for all models and data together
-    input_tune_out
-        .groupTuple()
-        .set{ ch2default }
+    // 1. Run the default analysis for all models and data together. group them by the same test set -> aka same split process
+    ch2default = input_tune_out.groupTuple(by: 1).view()
+    /*
     STIMULUS_ANALYSIS_DEFAULT(
         ch2default,
         input_model
     )
 
     // 2. Run the motif discovery block
-
+    */
 }

--- a/workflows/handle_analysis.nf
+++ b/workflows/handle_analysis.nf
@@ -21,13 +21,13 @@ workflow HANDLE_ANALYSIS {
     main:
    
     // 1. Run the default analysis for all models and data together. group them by the same test set -> aka same split process
-    ch2default = input_tune_out.groupTuple(by: 1).view()
-    /*
+    ch2default = input_tune_out.groupTuple()
+    
     STIMULUS_ANALYSIS_DEFAULT(
         ch2default,
         input_model
     )
 
     // 2. Run the motif discovery block
-    */
+    
 }

--- a/workflows/handle_data.nf
+++ b/workflows/handle_data.nf
@@ -62,7 +62,7 @@ workflow HANDLE_DATA {
 
     // unify transform output with interpret allinfo json. so that each final data has his own fingerprint json that generated it + keyword. drop all other non relevant fields.
     tmp = allinfo_json.combine( TRANSFORM_CSV.out.transformed_data, by: 0 ).map{
-        it -> [it[0], it[1], it[4]]
+        it -> ["${it[6].simpleName}-${it[0]}", it[1], it[4]]
     }
 
     // Launch the shuffle, (always happening on default) and disjointed from split and noise. Data are randomly splitted into this module already.

--- a/workflows/handle_data.nf
+++ b/workflows/handle_data.nf
@@ -60,7 +60,8 @@ workflow HANDLE_DATA {
     // launch the actual noise subworkflow
     TRANSFORM_CSV( transform_split_tuple )
 
-    // unify transform output with interpret experiment json. so that each final data has his own fingerprint json that generated it + keyword. drop all other non relevant fields.
+    // unify transform output with interpret experiment json. so that each final data has his own fingerprint json that generated it + keyword. drop all other non relevant fields. it0 is the unique key matching transform Json and the experiment Json (fingerprint), it6 is the original filename of the input data given by the user.
+    // it2 is the key used to match the splitted data with the correct transform Json (used later on by the analysis step to identify the models that have the same test set), it1 is the unique experimental config (the one containing all info for the given combination of split and transform and params values) it4  is the data csv transformed
     tmp = experiment_json.combine( TRANSFORM_CSV.out.transformed_data, by: 0 ).map{
         it -> ["${it[6].name} - ${it[0]}", it[2], it[1], it[4]]
     }

--- a/workflows/handle_data.nf
+++ b/workflows/handle_data.nf
@@ -62,7 +62,7 @@ workflow HANDLE_DATA {
 
     // unify transform output with interpret allinfo json. so that each final data has his own fingerprint json that generated it + keyword. drop all other non relevant fields.
     tmp = allinfo_json.combine( TRANSFORM_CSV.out.transformed_data, by: 0 ).map{
-        it -> ["${it[6].simpleName}-${it[0]}", it[1], it[4]]
+        it -> ["${it[6].name} - ${it[0]}", it[1], it[4]]
     }
 
     // Launch the shuffle, (always happening on default) and disjointed from split and noise. Data are randomly splitted into this module already.

--- a/workflows/handle_data.nf
+++ b/workflows/handle_data.nf
@@ -51,30 +51,10 @@ workflow HANDLE_DATA {
         it -> ["${it.baseName}".split('-')[0..-3].join("-"), "${it.baseName}".split('-')[-1], it]
     }
 
-    //allinfo_json.view()
-    split_json.view()
-    transform_json.view()
-    data = 'bubba'
-    /*
-
-    // for each user json many json wiil be created in the same process, but then we need to parallelize and work on them one by one.
-    all_exp_json = INTERPRET_JSON.out.interpreted_json.flatten().toSortedList()
-    all_exp_json.view()
-    // now we need to go from a list to a list of tuples with dir_name, list of files under that dir   as arguments
-    grouped_on_split_json = all_exp_json.map {
-        it -> ["${it.parent}".split('/')[-1], it]
-    }
-    //grouped_on_split_json.view()
-    // launch splitting subworkflow only once per split configuration/combination. It takes the first file of each tuple.
-    parsed_json = grouped_on_split_json.map {
-        
-        it -> it[1][0]
-    }
-    //parsed_json.view()
     
-    SPLIT_CSV(csv, parsed_json)
+    SPLIT_CSV(csv, split_json)
     data = SPLIT_CSV.out.split_data
-    
+    /*
 
     // launch the actual noise subworkflow
     TRANSFORM_CSV( SPLIT_CSV.out.split_data )

--- a/workflows/handle_data.nf
+++ b/workflows/handle_data.nf
@@ -36,11 +36,45 @@ workflow HANDLE_DATA {
     // read the json and create many json as there are combinations of noisers and splitters. the message_from_check is passed only to enforce that this modules does not run untill check_module is finished.
     INTERPRET_JSON(json, message_from_check)
 
+    // the above process outputs three channels one with all the information (split+ transform), one with only split info, and one with only transform. Each of this channels have to be transformed into a tuple with a common unique id for a given combination.
+    allinfo_json = INTERPRET_JSON.out.allinfo_json.flatten().map{
+        it -> ["${it.baseName}".split('-')[0..-2].join("-"), it]
+    }
+
+    // the split has only the keyword to match to the transform
+    split_json = INTERPRET_JSON.out.split_json.flatten().map{
+        it -> ["${it.baseName}".split('-')[-1], it]
+    }
+
+    // and transform has both keys to match to everything toghether
+    transform_json = INTERPRET_JSON.out.transform_json.flatten().map{
+        it -> ["${it.baseName}".split('-')[0..-3].join("-"), "${it.baseName}".split('-')[-1], it]
+    }
+
+    //allinfo_json.view()
+    split_json.view()
+    transform_json.view()
+    data = 'bubba'
+    /*
+
     // for each user json many json wiil be created in the same process, but then we need to parallelize and work on them one by one.
-    parsed_json = INTERPRET_JSON.out.interpreted_json.flatten()
+    all_exp_json = INTERPRET_JSON.out.interpreted_json.flatten().toSortedList()
+    all_exp_json.view()
+    // now we need to go from a list to a list of tuples with dir_name, list of files under that dir   as arguments
+    grouped_on_split_json = all_exp_json.map {
+        it -> ["${it.parent}".split('/')[-1], it]
+    }
+    //grouped_on_split_json.view()
+    // launch splitting subworkflow only once per split configuration/combination. It takes the first file of each tuple.
+    parsed_json = grouped_on_split_json.map {
+        
+        it -> it[1][0]
+    }
+    //parsed_json.view()
     
-    // launch splitting subworkflow 
     SPLIT_CSV(csv, parsed_json)
+    data = SPLIT_CSV.out.split_data
+    
 
     // launch the actual noise subworkflow
     TRANSFORM_CSV( SPLIT_CSV.out.split_data )
@@ -51,6 +85,7 @@ workflow HANDLE_DATA {
 
     // merge output of shuffle to the output of noise
     data = TRANSFORM_CSV.out.transformed_data.concat(SHUFFLE_CSV.out.shuffle_data)
+    */
 
     emit:
     data 

--- a/workflows/handle_data.nf
+++ b/workflows/handle_data.nf
@@ -63,14 +63,17 @@ workflow HANDLE_DATA {
     // unify transform output with interpret experiment json. so that each final data has his own fingerprint json that generated it + keyword. drop all other non relevant fields.
     tmp = experiment_json.combine( TRANSFORM_CSV.out.transformed_data, by: 0 ).map{
         it -> ["${it[6].name} - ${it[0]}", it[2], it[1], it[4]]
-    }.view()
-    /*
-    // Launch the shuffle, (always happening on default) and disjointed from split and noise. Data are randomly splitted into this module already.
-    // it takes a random json from those interpreted so that is dependant on that process and to have the experiment name key, used later in the train step.
+    }
+    
+    // Launch the shuffle, (always happening on default) and disjointed from noise. Data are taken from the no-split option of split module. Which means that is either randomly splitted with default values or using the column present in the data.
     // It can be still skipped but by default is run. shuffle is set to true in nextflow.config
     data = tmp
     if ( params.shuffle ) {
-        SHUFFLE_CSV( csv, experiment_json.first() )
+        // take the data from the no-split process
+        shuffle_correct_input = SPLIT_CSV.out.split_data.filter{
+            it[0] == 'no_split'
+        }
+        SHUFFLE_CSV( shuffle_correct_input )
         // merge output of shuffle to the output of noise
         data = tmp.concat( SHUFFLE_CSV.out.shuffle_data )
     }
@@ -78,7 +81,7 @@ workflow HANDLE_DATA {
 
     emit:
     data 
-    */
+    
 }
 
 

--- a/workflows/handle_tune.nf
+++ b/workflows/handle_tune.nf
@@ -28,7 +28,7 @@ workflow HANDLE_TUNE {
     // assign a model and a TUNE_config to each data
     model_conf_pair = model.combine(tune_config)
     model_conf_data = model_conf_pair.combine(data).map{ 
-        it -> [it[2], it[1], it[0], it[4], it[3]]
+        it -> [it[2], it[3], it[1], it[0], it[5], it[4]]
     }  // just reordering according to the inputs of the launch_tuning.py
     
 

--- a/workflows/handle_tune.nf
+++ b/workflows/handle_tune.nf
@@ -27,14 +27,18 @@ workflow HANDLE_TUNE {
 
     // assign a model and a TUNE_config to each data
     model_conf_pair = model.combine(tune_config)
-    model_conf_data = model_conf_pair.combine(data).map{ it -> [it[2], it[1], it[0], it[4], it[3]]}   // just reordering according to the inputs of the launch_TUNEing.py
+    model_conf_data = model_conf_pair.combine(data).map{ 
+        it -> [it[2], it[1], it[0], it[4], it[3]]
+    }  // just reordering according to the inputs of the launch_tuning.py
     
+
     // TUNE the torch model, TODO in future here switch TUNEing on basis of model type, keras tensorflow ecc.
     TORCH_TUNE( model_conf_data )
 
     emit:
     tune_out  = TORCH_TUNE.out.tune_specs
     model     = model
+    
 }
 
 


### PR DESCRIPTION
Now the split happens the right amount of times. To do so few changes were necessary:

1.  The interpret_json step now creates all the possible combination json with all info (split + transform) as well as json with either only split or transform information. The split_json will be the nuber of possible asked split ways + no-split. While the transform one will be redundant and be the same number of all possible combination of jsons (split + transform).
2. The interpret_json now handles null along side other split or transform arguments. This is done so that one can specify at the same time a method and also no-method whatsoever.
3. The json from interpret are called with a key in the filename so that later on the can be matched together. So that transform will run on the correct splitted associated data. 
4. Shuffle now depends also on the split step. Since there is always a no-split option in the pipeline it depends on thst. This is not the only reason why it depends on that. It is also because the no-split will do one of the following: if split column already present in data it does nothig, if not present it ramdom split with defoalt parameters. The latter is what was intended to be coupled with the shuffle of labels to begin with.
5. general renaming of variables tags and output files and directories.
6. the analysis part groups the models with the same test set (based on the split process) and compare models only within the same group (fair comparison). 