### PR TITLE
[feat] allow yaml file to provide single values

### DIFF
--- a/bin/launch_predict.py
+++ b/bin/launch_predict.py
@@ -24,7 +24,7 @@ def get_args():
     parser.add_argument("-d", "--data", type=str, required=True, metavar="FILE", help='Input data')
     parser.add_argument("-o", "--output", type=str, required=True, metavar="FILE", help="output predictions csv file")
     parser.add_argument("--split", type=int, help="The split of the data to use (default: None)")
-    parser.add_argument("--return_labels", type=bool, default=True, help="return the labels with the prediction (default: True)")
+    parser.add_argument("--return_labels", action='store_true', help="return the labels with the prediction")
 
     args = parser.parse_args()
     return args

--- a/bin/src/utils/yaml_model_schema.py
+++ b/bin/src/utils/yaml_model_schema.py
@@ -52,7 +52,6 @@ class YamlRayConfigLoader():
         # The space is the range of values to be tested, and the mode is the type of search to be done.
         # We convert the Yaml config by calling the correct function from ray.tune matching the mode, applied on the space
         # We return the config as a dictionary of dictionaries, where the values are the converted values from the space.
-        print(config)
         new_config = deepcopy(config)
         for key in ["model_params", "loss_params", "optimizer_params", "data_params"]:
             for sub_key in config[key]:

--- a/bin/src/utils/yaml_model_schema.py
+++ b/bin/src/utils/yaml_model_schema.py
@@ -52,11 +52,16 @@ class YamlRayConfigLoader():
         # The space is the range of values to be tested, and the mode is the type of search to be done.
         # We convert the Yaml config by calling the correct function from ray.tune matching the mode, applied on the space
         # We return the config as a dictionary of dictionaries, where the values are the converted values from the space.
-
+        print(config)
         new_config = deepcopy(config)
         for key in ["model_params", "loss_params", "optimizer_params", "data_params"]:
             for sub_key in config[key]:
-                new_config[key][sub_key] = self.convert_raytune(config[key][sub_key])
+
+                # if mode is provided, it understands that it is a ray.tune parameter
+                # therefore, it converts the space provided in the config to a ray.tune parameter space
+                # otherwise, it keeps the value as it is. In this way, we can use the same config for both ray.tune and non-ray.tune elements (for example provide a single fixed value).
+                if 'mode' in config[key][sub_key]:
+                    new_config[key][sub_key] = self.convert_raytune(config[key][sub_key])
 
         return new_config
     


### PR DESCRIPTION
[x] allow yaml file to provide single fix values (eg. sequence length, etc), without the need for creating ray tune space chosing from a range of values, etc.
[x] also fixed a bug in the launch_predict.py (as boolean arguments should be actions)